### PR TITLE
Add the Azure Boards badge to the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Board Status](https://dev.azure.com/pranekum/b224ae69-b336-4863-a1fd-b1182205c8e1/b024ca6e-be02-4d7d-b6ac-6e97b0cf7f19/_apis/work/boardbadge/0350885b-5a94-42cf-adb9-5c63fe6439e6)](https://dev.azure.com/pranekum/b224ae69-b336-4863-a1fd-b1182205c8e1/_boards/board/t/b024ca6e-be02-4d7d-b6ac-6e97b0cf7f19/Microsoft.RequirementCategory)
 # Contributing
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/). For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.


### PR DESCRIPTION
Add the Azure Boards badge for the board used to track the work for this repository. Fixes AB#179. See the [status badge configuration](https://aka.ms/azureboardsgithub-badge) documentation for more information.